### PR TITLE
Break API to allow integration with CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ omniauth-saml-va
 Example usage:
 
 ```Ruby
-if not ENV.has_key? 'SAML_XML_LOCATION'
-  raise 'SAML_XML_LOCATION is not set'
-end
-
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :samlva, 'CASEFLOW', ENV['SAML_PRIVATE_KEY'], ENV['SAML_XML_LOCATION'],
+  provider :samlva, 'CASEFLOW', ENV['SAML_PRIVATE_KEY'], ENV['SAML_CERTIFICATE'] ENV['SAML_XML_LOCATION'],
     :path_prefix => '/some-prefix/auth',
 end
 ```

--- a/lib/omniauth/strategies/samlva.rb
+++ b/lib/omniauth/strategies/samlva.rb
@@ -32,11 +32,11 @@ module OmniAuth
 
         options[:security] = {
           :authn_requests_signed    => sign,
-          :logout_requests_signed   => sign,
-          :logout_responses_signed  => sign,
-          :want_assertions_signed   => sign,
-          :metadata_signed          => sign,
-          :embed_sign               => sign,
+          :logout_requests_signed   => false,
+          :logout_responses_signed  => false,
+          :want_assertions_signed   => false,
+          :metadata_signed          => false,
+          :embed_sign               => false,
           :digest_method            => XMLSecurity::Document::SHA256,
           :signature_method         => XMLSecurity::Document::RSA_SHA256
         }

--- a/lib/omniauth/strategies/samlva.rb
+++ b/lib/omniauth/strategies/samlva.rb
@@ -7,7 +7,7 @@ require 'base64'
 module OmniAuth
   module Strategies
     class SAMLVA < OmniAuth::Strategies::SAML
-      def initialize(app, issuer=nil, private_key=nil, certificate=nil, configuration_xml=nil, options={}, &block)
+      def initialize(app, issuer=nil, private_key=nil, certificate=nil, configuration_xml=nil, sign=false, options={}, &block)
         doc = Nokogiri.XML(File.open(configuration_xml, 'rb'))
         cert = OpenSSL::X509::Certificate.new(Base64.decode64(doc.xpath(
             "//*[local-name()='KeyDescriptor']//*[local-name()='X509Certificate']/text()"
@@ -25,12 +25,12 @@ module OmniAuth
         options[:idp_cert] ||= cert.to_pem
         options[:name_identifier_format] ||= "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
         options[:security] = {
-          :authn_requests_signed    => true,
-          :logout_requests_signed   => true,
-          :logout_responses_signed  => true,
-          :want_assertions_signed   => true,
-          :metadata_signed          => true,
-          :embed_sign               => true,
+          :authn_requests_signed    => sign,
+          :logout_requests_signed   => sign,
+          :logout_responses_signed  => sign,
+          :want_assertions_signed   => sign,
+          :metadata_signed          => sign,
+          :embed_sign               => sign,
           :digest_method            => XMLSecurity::Document::SHA256,
           :signature_method         => XMLSecurity::Document::RSA_SHA256
         }

--- a/lib/omniauth/strategies/samlva.rb
+++ b/lib/omniauth/strategies/samlva.rb
@@ -7,6 +7,8 @@ require 'base64'
 module OmniAuth
   module Strategies
     class SAMLVA < OmniAuth::Strategies::SAML
+      attr_accessor :iam_provider
+
       def initialize(app, issuer=nil, private_key=nil, certificate=nil, configuration_xml=nil, sign=false, options={}, &block)
         doc = Nokogiri.XML(File.open(configuration_xml, 'rb'))
         cert = OpenSSL::X509::Certificate.new(Base64.decode64(doc.xpath(
@@ -17,6 +19,8 @@ module OmniAuth
         private_key = File.read(private_key)
         certificate = File.read(certificate)
 
+        self.iam_provider = options[:va_iam_provider]
+
         options[:issuer] = issuer
         options[:private_key] = private_key
         options[:certificate] = certificate
@@ -24,6 +28,8 @@ module OmniAuth
         options[:idp_sso_target_url] ||= location
         options[:idp_cert] ||= cert.to_pem
         options[:name_identifier_format] ||= "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+        options[:allowed_clock_drift] ||= 30.seconds
+
         options[:security] = {
           :authn_requests_signed    => sign,
           :logout_requests_signed   => sign,
@@ -38,9 +44,10 @@ module OmniAuth
         super(app, options, &block)
       end
 
-      # def request_phase
-      #   redirect("#{options[:idp_sso_target_url]}?SPID=#{options[:issuer]}")
-      # end
+      def request_phase
+        return redirect("#{options[:idp_sso_target_url]}?SPID=#{options[:issuer]}") if self.iam_provider == :iam
+        super
+      end
     end
   end
 end

--- a/omniauth-saml-va.gemspec
+++ b/omniauth-saml-va.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'paul.tagliamonte@va.gov'
   gem.homepage      = ''
 
-  gem.add_runtime_dependency 'omniauth-saml', '~> 1.5.0'
+  gem.add_runtime_dependency 'omniauth-saml', '~> 1.6.0'
 
   gem.files         = Dir['lib/**/*.rb']
   gem.require_paths = ["lib"]


### PR DESCRIPTION
 Add an additional argument, certificate, which must be set to the
 public x509 certificate file path (string) when using signed SAML auth.

 Readme has been updated to make sure our README isn't a total lie.

 The request phase has also been restored to initiate real SAML. This
 undos commit fb9ec34765a728fd5e4aa007415935fec69eb331. USA!

 Additionally, the defaults passed to ruby-saml will now set the XMLSEC
 signing to FULL CRYPTO. We also set the crypto defaults to use RSA256,
 and SHA256, since SHA1 is basically NASCAR at this point, there's going
 to be a collision, just don't know when. But it's coming.

 Remember kids, XMLSEC is all readability of XML combined with the bug
 free nature of using pointers. How can we go wrong?
