### PR TITLE
Upgrade omniauth-saml dependency

### DIFF
--- a/omniauth-saml-va.gemspec
+++ b/omniauth-saml-va.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'paul.tagliamonte@va.gov'
   gem.homepage      = ''
 
-  gem.add_runtime_dependency 'omniauth-saml', '~> 1.6.0'
+  gem.add_runtime_dependency 'omniauth-saml', '~> 1.8'
 
   gem.files         = Dir['lib/**/*.rb']
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Upgrade `omniauth-saml` dependency following that [package's update](https://github.com/omniauth/omniauth-saml/commit/335528312665633a4e7cac52040043544b920114) to mitigate the recently discovered [omniauth vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2017-18076).

Tested by making this change to a local clone of the repo, pointing efolder express at that local clone, running the bundler, and confirming that the efolder express test suite passed. Since there are [no other consumers of this package](https://github.com/department-of-veterans-affairs/omniauth-saml-va/network/dependents), I believe this change is safe to be released.