### PR TITLE
Merge Paultag/css branch into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ omniauth-saml-va
 Example usage:
 
 ```Ruby
-if not ENV.has_key? 'SAML_XML_LOCATION'
-  raise 'SAML_XML_LOCATION is not set'
-end
-
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :samlva, 'CASEFLOW', ENV['SAML_PRIVATE_KEY'], ENV['SAML_XML_LOCATION'],
+  provider :samlva, 'CASEFLOW', ENV['SAML_PRIVATE_KEY'], ENV['SAML_CERTIFICATE'] ENV['SAML_XML_LOCATION'],
     :path_prefix => '/some-prefix/auth',
 end
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ omniauth-saml-va
 Example usage:
 
 ```Ruby
+if not ENV.has_key? 'SAML_XML_LOCATION'
+  raise 'SAML_XML_LOCATION is not set'
+end
+
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :samlva, 'CASEFLOW', ENV['SAML_PRIVATE_KEY'], ENV['SAML_CERTIFICATE'] ENV['SAML_XML_LOCATION'],
+  provider :samlva, 'CASEFLOW', ENV['SAML_PRIVATE_KEY'], ENV['SAML_XML_LOCATION'],
     :path_prefix => '/some-prefix/auth',
 end
 ```

--- a/lib/omniauth/strategies/samlva.rb
+++ b/lib/omniauth/strategies/samlva.rb
@@ -32,11 +32,11 @@ module OmniAuth
 
         options[:security] = {
           :authn_requests_signed    => sign,
-          :logout_requests_signed   => sign,
-          :logout_responses_signed  => sign,
-          :want_assertions_signed   => sign,
-          :metadata_signed          => sign,
-          :embed_sign               => sign,
+          :logout_requests_signed   => false,
+          :logout_responses_signed  => false,
+          :want_assertions_signed   => false,
+          :metadata_signed          => false,
+          :embed_sign               => false,
           :digest_method            => XMLSecurity::Document::SHA256,
           :signature_method         => XMLSecurity::Document::RSA_SHA256
         }

--- a/lib/omniauth/strategies/samlva.rb
+++ b/lib/omniauth/strategies/samlva.rb
@@ -7,7 +7,7 @@ require 'base64'
 module OmniAuth
   module Strategies
     class SAMLVA < OmniAuth::Strategies::SAML
-      def initialize(app, issuer=nil, private_key=nil, certificate=nil, configuration_xml=nil, options={}, &block)
+      def initialize(app, issuer=nil, private_key=nil, certificate=nil, configuration_xml=nil, sign=false, options={}, &block)
         doc = Nokogiri.XML(File.open(configuration_xml, 'rb'))
         cert = OpenSSL::X509::Certificate.new(Base64.decode64(doc.xpath(
             "//*[local-name()='KeyDescriptor']//*[local-name()='X509Certificate']/text()"
@@ -25,12 +25,12 @@ module OmniAuth
         options[:idp_cert] ||= cert.to_pem
         options[:name_identifier_format] ||= "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
         options[:security] = {
-          :authn_requests_signed    => true,
-          :logout_requests_signed   => true,
-          :logout_responses_signed  => true,
-          :want_assertions_signed   => true,
-          :metadata_signed          => true,
-          :embed_sign               => true,
+          :authn_requests_signed    => sign,
+          :logout_requests_signed   => sign,
+          :logout_responses_signed  => sign,
+          :want_assertions_signed   => sign,
+          :metadata_signed          => sign,
+          :embed_sign               => sign,
           :digest_method            => XMLSecurity::Document::SHA256,
           :signature_method         => XMLSecurity::Document::RSA_SHA256
         }

--- a/lib/omniauth/strategies/samlva.rb
+++ b/lib/omniauth/strategies/samlva.rb
@@ -7,6 +7,8 @@ require 'base64'
 module OmniAuth
   module Strategies
     class SAMLVA < OmniAuth::Strategies::SAML
+      attr_accessor :iam_provider
+
       def initialize(app, issuer=nil, private_key=nil, certificate=nil, configuration_xml=nil, sign=false, options={}, &block)
         doc = Nokogiri.XML(File.open(configuration_xml, 'rb'))
         cert = OpenSSL::X509::Certificate.new(Base64.decode64(doc.xpath(
@@ -17,6 +19,8 @@ module OmniAuth
         private_key = File.read(private_key)
         certificate = File.read(certificate)
 
+        self.iam_provider = options[:va_iam_provider]
+
         options[:issuer] = issuer
         options[:private_key] = private_key
         options[:certificate] = certificate
@@ -24,6 +28,8 @@ module OmniAuth
         options[:idp_sso_target_url] ||= location
         options[:idp_cert] ||= cert.to_pem
         options[:name_identifier_format] ||= "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+        options[:allowed_clock_drift] ||= 30.seconds
+
         options[:security] = {
           :authn_requests_signed    => sign,
           :logout_requests_signed   => sign,
@@ -38,9 +44,10 @@ module OmniAuth
         super(app, options, &block)
       end
 
-      # def request_phase
-      #   redirect("#{options[:idp_sso_target_url]}?SPID=#{options[:issuer]}")
-      # end
+      def request_phase
+        return redirect("#{options[:idp_sso_target_url]}?SPID=#{options[:issuer]}") if self.iam_provider == :iam
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
This change incorporates the changes from the paultag/css branch into the master branch.

efolder express is the [only consumer](https://github.com/department-of-veterans-affairs/omniauth-saml-va/network/dependents) of this package, yet efolder express [uses the paultag/css branch](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/d18f95f7f1aca504dc323210a7f9d904e68304b5/Gemfile#L47) of this repo, so the only version of this code that is being used is the paultag/css branch. I find this counterintuitive and fear that it could cause problems in the future if people make changes to the master branch believing they are changing the version of the package that consumers are actually using (see #9). This change assuages those concerns by folding this branch into master.