### PR TITLE
Increase dependency version now that it was officially bumped

### DIFF
--- a/omniauth-saml-va.gemspec
+++ b/omniauth-saml-va.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'paul.tagliamonte@va.gov'
   gem.homepage      = ''
 
-  gem.add_runtime_dependency 'omniauth-saml', '~> 1.8'
+  gem.add_runtime_dependency 'omniauth-saml', '~> 1.9'
 
   gem.files         = Dir['lib/**/*.rb']
   gem.require_paths = ["lib"]


### PR DESCRIPTION
`omniauth-saml` changed its version number to 1.9.0 just now in order to have a specific version number that mitigates the `omniauth` vulnerability (PR: https://github.com/omniauth/omniauth-saml/commit/f0deffed88f8d765d3c317413043a60f043b42f1, library entry: https://rubygems.org/gems/omniauth-saml). We should update our dependency version to more precisely include that vulnerability mitigation.