### PR TITLE
Upgrade omniauth-saml to mitigate CVE-2017-11428

### DIFF
--- a/omniauth-saml-va.gemspec
+++ b/omniauth-saml-va.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'paul.tagliamonte@va.gov'
   gem.homepage      = ''
 
-  gem.add_runtime_dependency 'omniauth-saml', '~> 1.9'
+  gem.add_runtime_dependency 'omniauth-saml', ref: '2d50dbae7fc2d19c4550c5ddadb0377bb3a71874'
 
   gem.files         = Dir['lib/**/*.rb']
   gem.require_paths = ["lib"]


### PR DESCRIPTION
omniauth-saml hasn't yet tagged this commit with a release version so we are using a hash to reference the release so we can continue to push code to efolder.

Information on vulnerability here: https://www.securityweek.com/widespread-vulnerability-found-single-sign-products